### PR TITLE
fix!: handle paths in `routets` CLI correctly

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,9 @@
 name: Deploy
 on:
   push:
-    branches: develop
+    branches: [develop]
   pull_request:
-    branches: develop
+    branches: [develop]
 
 jobs:
   deploy:
@@ -30,5 +30,4 @@ jobs:
         uses: denoland/deployctl@v1
         with:
           project: "routets-examples"
-          entrypoint: "examples/serve.gen.ts"
-          root: ""
+          entrypoint: "serve.gen.ts"

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Notably, use of suffix allows you to place related modules like `*.test.ts` asid
 
 Basically, `routets` uses non-statically-analyzeable dynamic imports to discover routes. This works well locally, but can be a problem if you want to get it to work with environments that don't support non-statically-analyzeable dynamic imports, such as [Deno Deploy](https://github.com/denoland/deploy_feedback/issues/433).
 
-For this use case, you can use `routets --write serve.gen.ts` which generates an index module at the specified path (relative to the serving root) that does only statically-analyzeable dynamic import of routes. This module can directly be used as the entrypoint for Deno Deploy.
+For this use case, you can use `routets --write serve.gen.ts` which generates an index module at the specified path (relative from the serving root) that does only statically-analyzeable dynamic import of routes. This module can directly be used as the entrypoint for Deno Deploy.
 
 ## Difference from `fsrouter`
 

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -33,7 +33,7 @@ const isOptionsNormalized = (
 
 const getUrlCallSite = (cursor: number) => {
 	try {
-		// console.log(callsites().map(callsite => callsite.toString()))
+		// console.log(callsites().map(callSite => callSite.toString()))
 		const path = callsites()[cursor]?.getFileName() || undefined
 		if (path === undefined) throw undefined
 		return toFileUrl(path)
@@ -45,9 +45,11 @@ const getUrlCallSite = (cursor: number) => {
 const normalizeOptions = (options: Router.Options | OptionsNormalized): OptionsNormalized => {
 	if (isOptionsNormalized(options)) return options
 
-	if (options.root === "") throw new Error("root path cannot be empty.")
-	const root = new URL(options.root ?? ".", getUrlCallSite(3))
-	if (!isFileUrl(root)) throw new Error("Only local paths or file URLs are supported.")
+	const callSite = getUrlCallSite(3)
+
+	if (options.root === "") throw new Error("Root path cannot be empty.")
+	const root = new URL(options.root ?? ".", callSite)
+	if (!isFileUrl(root)) throw new Error("Root path can only be a local path or a file URL.")
 	if (!root.pathname.endsWith("/")) root.pathname += "/"
 
 	if (options.suffix === "") throw new Error("Suffix cannot be empty.")
@@ -57,7 +59,7 @@ const normalizeOptions = (options: Router.Options | OptionsNormalized): OptionsN
 		throw new Error("Suffix cannot start or end with dots.")
 	const pattern = createRegExpFromSuffix(suffix)
 
-	const write = options.write && new URL(options.write, root)
+	const write = options.write && new URL(options.write, callSite)
 	if (write === "") throw new Error("Index module file path cannot be empty.")
 	if (write?.pathname.match(pattern)?.groups?.pattern !== undefined)
 		throw new Error("Index module file path cannot ends with a valid route filename.")
@@ -68,12 +70,12 @@ const normalizeOptions = (options: Router.Options | OptionsNormalized): OptionsN
 			: options.watch === false || options.watch === undefined
 				? []
 				: typeof options.watch === "string"
-					? [new URL(options.watch, root)]
+					? [new URL(options.watch, callSite)]
 					: options.watch instanceof URL
 						? [options.watch]
-						: options.watch.map(path => new URL(path, root))
+						: options.watch.map(path => new URL(path, callSite))
 
-	const importMap = options.importMap ? new URL(options.importMap, root) : undefined
+	const importMap = options.importMap ? new URL(options.importMap, callSite) : undefined
 
 	return { root, pattern, write, watch, importMap, [normalized]: undefined }
 }
@@ -152,21 +154,19 @@ const enumerate = async ({ root, pattern }: OptionsNormalized): Promise<Router.R
 }
 
 const emit = async (root: URL, routes: Router.Routes, path: URL) => {
+	const { relative } = await import("https://esm.sh/jsr/@std/path@1.0.9/posix/relative.ts")
+	const { dirname } = await import("https://esm.sh/jsr/@std/path@1.0.9/posix/dirname.ts")
+	const from = dirname(path.pathname)
 	const routetslist = routes
 		.map(
-			([path, route]) =>
+			([pathRoute, route]) =>
 				`[${JSON.stringify(route.pattern.pathname)}, (await import(${JSON.stringify(
-					`./${encodeUriPathname(path)}`,
+					`./${encodeUriPathname(relative(from, new URL(pathRoute, root).pathname))}`,
 				)})).default]`,
 		)
 		.join(",\n\t")
 	const self = new URL(import.meta.url)
-	const specifierRouter = isFileUrl(self)
-		? `./${(await import("https://esm.sh/jsr/@std/path@1.0.9/relative.ts")).relative(
-				root.pathname,
-				self.pathname,
-			)}`
-		: self.href
+	const specifierRouter = isFileUrl(self) ? `./${relative(from, self.pathname)}` : self.href
 	let content = `import Router from "${specifierRouter}"`
 	content += `\nconst routetslist = [\n\t${routetslist}\n] as const`
 	content += `\nawait Deno.serve(new Router(routetslist)).finished`
@@ -189,6 +189,8 @@ namespace Router {
 		/**
 		 * The serving root directory to search for routes.
 		 *
+		 * Relative from the call site of the function to which this option will be passed.
+		 *
 		 * @default "."
 		 */
 		readonly root?: string | URL | undefined
@@ -199,7 +201,9 @@ namespace Router {
 		 */
 		readonly suffix?: string | undefined
 		/**
-		 * Whether to generate the index module, which is necessary for deployments to environments that don't support dynamic imports, such as Deno Deploy.
+		 * The path to generate an index module at, which is necessary for deployments to environments that don't support dynamic imports, such as Deno Deploy.
+		 *
+		 * Relative from the call site of the function to which this option will be passed.
 		 *
 		 * @default undefined
 		 */
@@ -207,11 +211,15 @@ namespace Router {
 		/**
 		 * Where to watch for changes and update the routes automatically. If `true`, the same path as the `root` is used.
 		 *
+		 * Relative from the call site of the function to which this option will be passed.
+		 *
 		 * @default false
 		 */
 		readonly watch?: boolean | string | URL | readonly (string | URL)[] | undefined
 		/**
 		 * The path to the JSON file representing the import map to be used while watching.
+		 *
+		 * Relative from the call site of the function to which this option will be passed.
 		 *
 		 * @default undefined
 		 */

--- a/src/routets.ts
+++ b/src/routets.ts
@@ -15,6 +15,7 @@ const tryFindConfigCwd = async (pathToDenoManifest: string) => {
 
 const cwd = Deno.cwd()
 const toAbsolute = (path: string) => (isAbsolute(path) ? path : resolve(cwd, path))
+const toFileUrl = (path: string) => new URL(toAbsolute(path), "file:")
 
 const [first, ...rest] = Deno.args
 const argsRaw = first === marker ? rest : Deno.args
@@ -32,19 +33,19 @@ const { args, options } = await new Command()
 	)
 	.option(
 		"--watch [...paths:string]",
-		"Enables watching for file changes and reloading routes. Without paths, the same directory as `root` is implied.",
+		"Enables watching for file changes and reloading routes. Without paths, the same directory as `root` is implied. Supports multiple paths, relative from the current working directory.",
 		{ default: true },
 	)
 	.option("--no-watch", "Disables watching.")
 	.option(
 		"--write <path:string>",
-		"Enables generating an index module at the specified path, relative to `root`. With `--watch` option, it is rewritten on every change. The path cannot ends with a valid route filename.",
+		"Enables generating an index module at the specified path, relative from the current working directory. With `--watch` option, it is rewritten on every change. The path cannot ends with a valid route filename.",
 		{ default: undefined },
 	)
 	.option("--no-serve", "Disables serving. Useful when you only want to generate an index module.")
 	.option(
 		"--config <path:string>",
-		"Specifies a path to the Deno maifest JSON file i.e. `deno.json` or `deno.jsonc`. Defaulting to the one in the current working directory if it exists.",
+		"Specifies a path to the Deno maifest JSON file i.e. `deno.json` or `deno.jsonc`, relative from the current working directory. Defaulting to the one in the current working directory if it exists.",
 	)
 	.option(
 		"--import-map <path:string>",
@@ -61,7 +62,7 @@ const { args, options } = await new Command()
 	.parse(argsRaw)
 const {
 	suffix,
-	write,
+	write: writeSpecified,
 	watch: watchSpecified,
 	serve,
 	config: configSpecified,
@@ -70,18 +71,18 @@ const {
 	port: portSpecified,
 } = options
 
-const config =
-	(configSpecified && toAbsolute(configSpecified)) ||
-	(await tryFindConfigCwd("deno.jsonc")
-		.catch(async () => await tryFindConfigCwd("deno.json"))
-		.then(toAbsolute)
-		.catch(() => undefined))
-const importMap = importMapSpecified && toAbsolute(importMapSpecified)
+const config = configSpecified
+	? toFileUrl(configSpecified)
+	: await tryFindConfigCwd("deno.jsonc")
+			.catch(async () => await tryFindConfigCwd("deno.json"))
+			.then(toFileUrl)
+			.catch(() => undefined)
+const importMap = importMapSpecified && toFileUrl(importMapSpecified)
 
 if (import.meta.main && Deno.args[0] !== marker) {
 	// Required running in another process, because installed scripts don't support import maps out of the box.
-	const argsConfig = config ? ["--config", config] : []
-	const argsImportMap = importMap ? ["--import-map", importMap] : []
+	const argsConfig = config ? ["--config", config.pathname] : []
+	const argsImportMap = importMap ? ["--import-map", importMap.pathname] : []
 	const command = new Deno.Command(Deno.execPath(), {
 		args: ["run", "-A", ...argsConfig, ...argsImportMap, import.meta.url, marker, ...Deno.args],
 		...{ stdin: "piped", stdout: "piped", stderr: "piped" },
@@ -96,10 +97,14 @@ if (import.meta.main && Deno.args[0] !== marker) {
 		const [rootSpecified = cwd, ...rest] = args
 		if (rest.length) throw new Error(`Unexpected arguments: ${rest.join(" ")}`)
 
-		const root = toAbsolute(rootSpecified)
-		const watch = (
-			watchSpecified === true ? [root] : watchSpecified === false ? [] : watchSpecified
-		).map(toAbsolute)
+		const root = toFileUrl(rootSpecified)
+		const watch =
+			watchSpecified === true
+				? [root]
+				: watchSpecified === false
+					? []
+					: watchSpecified.map(toFileUrl)
+		const write = writeSpecified && toFileUrl(writeSpecified)
 
 		if (serve) {
 			let port: number | undefined = undefined


### PR DESCRIPTION
This PR also changes every path-specifying option of CLI to relative from the CWD, and of `Router.Options` to relative from the call site of `Router` methods.